### PR TITLE
Remove tightly coupling of publish task name

### DIFF
--- a/src/main/groovy/org/jetbrains/intellij/PublishTask.groovy
+++ b/src/main/groovy/org/jetbrains/intellij/PublishTask.groovy
@@ -12,7 +12,6 @@ public class PublishTask extends DefaultTask {
     public static String NAME = "publishPlugin"
 
     public PublishTask() {
-        name = NAME
         group = IntelliJPlugin.GROUP_NAME
         description = "Publish plugin distribution on plugins.jetbrains.com."
     }


### PR DESCRIPTION
Currently, if you want to make your own publish task,
its name is set to a hardcoded name "publishArtifact".

Typically, this field is set by the gradle environment during
factory construction, and so mutating the state of this creates
inconsistencies where gradle _thinks_ a task has one name,
but the task itself does not report to that name.

This conflict prevents the task from being executed.
